### PR TITLE
Fix command adapter.

### DIFF
--- a/adapters/ros_command_adapter.cpp
+++ b/adapters/ros_command_adapter.cpp
@@ -122,8 +122,11 @@ RosCommandAdapter::initMUSIC(int argc, char** argv)
     }
     
     datasize = width;
-    data = new double[datasize+1]; //+1 for the leading zero needed for unspecified fiels in the message 
-    data[0] = 0.;
+    data = new double[datasize+1]; // +1 for the leading zero needed for unspecified fields in the message
+    for (size_t i = 0; i < datasize + 1; ++i)
+    {
+        data[i] = 0.;
+    }
          
     // Declare where in memory to put data
     MUSIC::ArrayData dmap (&data[1],

--- a/adapters/ros_command_adapter.cpp
+++ b/adapters/ros_command_adapter.cpp
@@ -180,8 +180,7 @@ RosCommandAdapter::readMappingFile()
             msg_type = Twist;
             msg_map = new int[n_components];
 
-            size_t index;
-            for (index = 0; index < n_components; index++)
+            for (size_t index = 0; index < n_components; index++)
             {
                 msg_map[index] = json_mapping["mapping"].get(components[index], -1).asInt() + 1;
             }

--- a/adapters/ros_command_adapter.cpp
+++ b/adapters/ros_command_adapter.cpp
@@ -168,33 +168,20 @@ RosCommandAdapter::readMappingFile()
         }
         else if (_msg_type.compare("Twist") == 0)
         {
-            msg_type = Twist;
+            const char *components[] = {
+                "linear.x", "linear.y", "linear.z",
+                "angular.x", "angular.y", "angular.z"
+            };
+            const size_t n_components = sizeof(components) / sizeof(components[0]);
             
-            msg_map = new int[6];
-            int index = -1;
+            msg_type = Twist;
+            msg_map = new int[n_components];
 
-            index = json_mapping["mapping"]["linear.x"].asInt();
-            msg_map[0] = index + 1;
-
-            index = -1;
-            index = json_mapping["mapping"]["linear.y"].asInt();
-            msg_map[1] = index + 1;
-
-            index = -1;
-            index = json_mapping["mapping"]["linear.z"].asInt();
-            msg_map[2] = index + 1;
-
-            index = -1;
-            index = json_mapping["mapping"]["angular.x"].asInt();
-            msg_map[3] = index + 1;
-
-            index = -1;
-            index = json_mapping["mapping"]["angular.y"].asInt();
-            msg_map[4] = index + 1;
-
-            index = -1;
-            index = json_mapping["mapping"]["angular.z"].asInt();
-            msg_map[5] = index + 1;
+            size_t index;
+            for (index = 0; index < n_components; index++)
+            {
+                msg_map[index] = json_mapping["mapping"].get(components[index], -1).asInt() + 1;
+            }
         }
         else
         {


### PR DESCRIPTION
`jsoncpp` returns 0 and not -1 if fields are not mapped. Thus, those field are not simply set to zero, but reference the first data entry (as if "0" would have been specified for them).